### PR TITLE
v1.1.0へ更新

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ modGroup = kpan.better_fc
 
 # Version of your mod.
 # This field can be left empty if you want your mod's version to be determined by the latest git tag instead.
-modVersion = 1.0.0
+modVersion = 1.1.0
 
 # Whether to use the old jar naming structure (modid-mcversion-version) instead of the new version (modid-version)
 includeMCVersionJar = true

--- a/src/main/java/kpan/better_fc/api/IRenderingEffectSingleColor.java
+++ b/src/main/java/kpan/better_fc/api/IRenderingEffectSingleColor.java
@@ -1,0 +1,7 @@
+package kpan.better_fc.api;
+
+import net.minecraft.client.gui.FontRenderer;
+
+public interface IRenderingEffectSingleColor extends IRenderingEffectColor {
+	int getColor(FontRenderer fontRenderer);
+}

--- a/src/main/java/kpan/better_fc/api/RenderFontUtil.java
+++ b/src/main/java/kpan/better_fc/api/RenderFontUtil.java
@@ -1331,6 +1331,20 @@ public class RenderFontUtil {
 		return result;
 	}
 
+	//getColor
+	public static int getColor(FontRenderer fontRenderer, Collection<IRenderingCharEffect> effects) {
+		int color = -1;
+		for (IRenderingCharEffect effect : effects) {
+			if (effect instanceof IRenderingEffectColor c) {
+				if (c instanceof IRenderingEffectSingleColor)
+					color = ((IRenderingEffectSingleColor) c).getColor(fontRenderer);
+				else
+					color = -1;
+			}
+		}
+		return color;
+	}
+
 	//fontRendererUtils
 	public static float drawString(FontRenderer fontRenderer, String text, float x, float y, int color) {
 		return drawString(fontRenderer, text, x, y, color, false);

--- a/src/main/java/kpan/better_fc/api/RenderFontUtil.java
+++ b/src/main/java/kpan/better_fc/api/RenderFontUtil.java
@@ -42,7 +42,6 @@ public class RenderFontUtil {
 	private static List<IRenderingCharEffect> validDisplay = null;
 	private static List<IRenderingCharEffect> invalidDisplay = null;
 	public static final List<IRenderingCharEffect> appliedEffects = new ArrayList<>();
-	public static boolean useIntWidth = true;
 	public static boolean isEditMode = false;
 
 	public static List<IRenderingCharEffect> getValidDisplayEffects() {
@@ -241,12 +240,12 @@ public class RenderFontUtil {
 							return;
 						char ch = context.originalText.charAt(i);
 						if (context.isEdit) {
-							context.posX += prepareAndRenderChar(context, ch, useIntWidth);
+							context.posX += prepareAndRenderChar(context, ch);
 						} else {
 							CharArrayRingList ringList = context.getRingList();
 							ringList.addLast(ch);
 							while (!ringList.isEmpty()) {
-								context.posX += prepareAndRenderChar(context, ringList.pollFirst(), useIntWidth);
+								context.posX += prepareAndRenderChar(context, ringList.pollFirst());
 							}
 						}
 					}
@@ -257,21 +256,21 @@ public class RenderFontUtil {
 					GlStateManager.color(context.fontRenderer.red, context.fontRenderer.green, context.fontRenderer.blue, context.fontRenderer.alpha);
 					//§の次が無い
 					if (context.isEdit)
-						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, getInvalidDisplayEffects(), context.asShadow, useIntWidth);
+						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, getInvalidDisplayEffects(), context.asShadow);
 					else
-						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, Collections.emptyList(), context.asShadow, useIntWidth);
+						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, Collections.emptyList(), context.asShadow);
 				}
 				case ESCAPED_SECTION_SIGN -> {
 					if (beginIndex >= wholeEndIndexExcl)
 						return;
 					if (context.isEdit) {
 						GlStateManager.color(context.fontRenderer.red, context.fontRenderer.green, context.fontRenderer.blue, context.fontRenderer.alpha);
-						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, getValidDisplayEffects(), context.asShadow, useIntWidth);
+						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, getValidDisplayEffects(), context.asShadow);
 						if (beginIndex + 1 >= wholeEndIndexExcl)
 							return;
-						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, getValidDisplayEffects(), context.asShadow, useIntWidth);
+						context.posX += renderChar(context.fontRenderer, '§', context.posX, context.posY, getValidDisplayEffects(), context.asShadow);
 					} else {
-						context.posX += prepareAndRenderChar(context, '§', useIntWidth);
+						context.posX += prepareAndRenderChar(context, '§');
 					}
 				}
 				case FORMATTING_CODE_UNTERMINATED_LONGKEY, FORMATTING_CODE_UNKNOWN -> {
@@ -286,13 +285,13 @@ public class RenderFontUtil {
 							for (int i = Math.max(beginIndex, wholeBeginIndex); i < endIndexExcl; i++) {
 								if (i >= wholeEndIndexExcl)
 									return;
-								context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow, useIntWidth);
+								context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow);
 							}
 						} else {
 							CharArrayRingList ringList = context.getRingList();
 							while (!ringList.isEmpty()) {
 								char c1 = ringList.pollFirst();
-								context.posX += prepareAndRenderChar(context, c1, useIntWidth);
+								context.posX += prepareAndRenderChar(context, c1);
 							}
 						}
 					} else {
@@ -307,7 +306,7 @@ public class RenderFontUtil {
 						for (int i = Math.max(beginIndex, wholeBeginIndex); i < beginIndex + 1 + markerNum; i++) {
 							if (i >= wholeEndIndexExcl)
 								return;
-							context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow, useIntWidth);
+							context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow);
 						}
 					} else {
 						if (type == Type.FORMATTING_RANGE_UNTERMINATED) {
@@ -315,7 +314,7 @@ public class RenderFontUtil {
 							for (int i = Math.max(beginIndex, wholeBeginIndex); i < beginIndex + 1 + markerNum; i++) {
 								if (i >= wholeEndIndexExcl)
 									return;
-								context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow, useIntWidth);
+								context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow);
 							}
 						}
 					}
@@ -328,7 +327,7 @@ public class RenderFontUtil {
 							for (int i = endIndexExcl - markerNum; i < endIndexExcl; i++) {
 								if (i >= wholeEndIndexExcl)
 									return;
-								context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow, useIntWidth);
+								context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getValidDisplayEffects(), context.asShadow);
 							}
 						}
 					}
@@ -342,7 +341,7 @@ public class RenderFontUtil {
 			for (int i = Math.max(beginIndex, wholeBeginIndex); i < endIndexExcl; i++) {
 				if (i >= wholeEndIndexExcl)
 					return true;
-				context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getInvalidDisplayEffects(), context.asShadow, useIntWidth);
+				context.posX += renderChar(context.fontRenderer, context.originalText.charAt(i), context.posX, context.posY, getInvalidDisplayEffects(), context.asShadow);
 			}
 			return false;
 		}
@@ -359,7 +358,7 @@ public class RenderFontUtil {
 							return new MeasuringResult(currentWidth, i);
 						char ch = context.originalText.charAt(i);
 						if (context.isEdit) {
-							float w = prepareAndGetCharWidth(context, ch, useIntWidth);
+							float w = prepareAndGetCharWidth(context, ch);
 							if (currentWidth + w > limitWidthIncl)
 								return new MeasuringResult(currentWidth, i);
 							currentWidth += w;
@@ -367,7 +366,7 @@ public class RenderFontUtil {
 							CharArrayRingList ringList = context.getRingList();
 							ringList.addLast(ch);
 							while (!ringList.isEmpty()) {
-								float w = prepareAndGetCharWidth(context, ringList.pollFirst(), useIntWidth);
+								float w = prepareAndGetCharWidth(context, ringList.pollFirst());
 								if (currentWidth + w > limitWidthIncl)
 									return new MeasuringResult(currentWidth, i);
 								currentWidth += w;
@@ -381,9 +380,9 @@ public class RenderFontUtil {
 					//§の次が無い
 					float w;
 					if (context.isEdit)
-						w = getCharWidthWithSpace(context.fontRenderer, '§', getInvalidDisplayEffects(), useIntWidth);
+						w = getCharWidthWithSpace(context.fontRenderer, '§', getInvalidDisplayEffects());
 					else
-						w = getCharWidthWithSpace(context.fontRenderer, '§', Collections.emptyList(), useIntWidth);
+						w = getCharWidthWithSpace(context.fontRenderer, '§', Collections.emptyList());
 					if (currentWidth + w > limitWidthIncl)
 						return new MeasuringResult(currentWidth, beginIndex);
 					currentWidth += w;
@@ -392,7 +391,7 @@ public class RenderFontUtil {
 					if (beginIndex >= wholeEndIndexExcl)
 						return new MeasuringResult(currentWidth, beginIndex);
 					if (context.isEdit) {
-						float w = getCharWidthWithSpace(context.fontRenderer, '§', getValidDisplayEffects(), useIntWidth);
+						float w = getCharWidthWithSpace(context.fontRenderer, '§', getValidDisplayEffects());
 						if (currentWidth + w > limitWidthIncl)
 							return new MeasuringResult(currentWidth, beginIndex);
 						currentWidth += w;
@@ -402,7 +401,7 @@ public class RenderFontUtil {
 							return new MeasuringResult(currentWidth, beginIndex + 1);
 						currentWidth += w;
 					} else {
-						float w = prepareAndGetCharWidth(context, '§', useIntWidth);
+						float w = prepareAndGetCharWidth(context, '§');
 						if (currentWidth + w > limitWidthIncl)
 							return new MeasuringResult(currentWidth, beginIndex);
 						currentWidth += w;
@@ -412,7 +411,7 @@ public class RenderFontUtil {
 					for (int i = Math.max(beginIndex, wholeBeginIndex); i < endIndexExcl; i++) {
 						if (i >= wholeEndIndexExcl)
 							return new MeasuringResult(currentWidth, i);
-						float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects(), useIntWidth);
+						float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects());
 						if (currentWidth + w > limitWidthIncl)
 							return new MeasuringResult(currentWidth, i);
 						currentWidth += w;
@@ -425,7 +424,7 @@ public class RenderFontUtil {
 							for (int i = Math.max(beginIndex, wholeBeginIndex); i < endIndexExcl; i++) {
 								if (i >= wholeEndIndexExcl)
 									return new MeasuringResult(currentWidth, i);
-								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 								if (currentWidth + w > limitWidthIncl)
 									return new MeasuringResult(currentWidth, i);
 								currentWidth += w;
@@ -433,7 +432,7 @@ public class RenderFontUtil {
 						} else {
 							CharArrayRingList ringList = context.getRingList();
 							while (!ringList.isEmpty()) {
-								float w = prepareAndGetCharWidth(context, ringList.pollFirst(), useIntWidth);
+								float w = prepareAndGetCharWidth(context, ringList.pollFirst());
 								if (currentWidth + w > limitWidthIncl)
 									return new MeasuringResult(currentWidth, endIndexExcl);
 								currentWidth += w;
@@ -443,7 +442,7 @@ public class RenderFontUtil {
 						for (int i = Math.max(beginIndex, wholeBeginIndex); i < endIndexExcl; i++) {
 							if (i >= wholeEndIndexExcl)
 								return new MeasuringResult(currentWidth, i);
-							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects(), useIntWidth);
+							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects());
 							if (currentWidth + w > limitWidthIncl)
 								return new MeasuringResult(currentWidth, i);
 							currentWidth += w;
@@ -456,7 +455,7 @@ public class RenderFontUtil {
 						for (int i = Math.max(beginIndex, wholeBeginIndex); i < beginIndex + 1 + markerNum; i++) {
 							if (i >= wholeEndIndexExcl)
 								return new MeasuringResult(currentWidth, i);
-							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 							if (currentWidth + w > limitWidthIncl)
 								return new MeasuringResult(currentWidth, i);
 							currentWidth += w;
@@ -466,7 +465,7 @@ public class RenderFontUtil {
 							for (int i = Math.max(beginIndex, wholeBeginIndex); i < beginIndex + 1 + markerNum; i++) {
 								if (i >= wholeEndIndexExcl)
 									return new MeasuringResult(currentWidth, i);
-								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 								if (currentWidth + w > limitWidthIncl)
 									return new MeasuringResult(currentWidth, i);
 								currentWidth += w;
@@ -486,7 +485,7 @@ public class RenderFontUtil {
 							for (int i = endIndexExcl - markerNum; i < endIndexExcl; i++) {
 								if (i >= wholeEndIndexExcl)
 									return new MeasuringResult(currentWidth, i);
-								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 								if (currentWidth + w > limitWidthIncl)
 									return new MeasuringResult(currentWidth, i);
 								currentWidth += w;
@@ -512,14 +511,14 @@ public class RenderFontUtil {
 					for (int i = beginIndex; i < endIndexExcl; i++) {
 						char ch = context.originalText.charAt(i);
 						if (context.isEdit) {
-							float w = prepareAndGetCharWidth(context, ch, useIntWidth);
+							float w = prepareAndGetCharWidth(context, ch);
 							widths[i] = w;
 						} else {
 							float total_width = 0;
 							CharArrayRingList ringList = context.getRingList();
 							ringList.addLast(ch);
 							while (!ringList.isEmpty()) {
-								float w = prepareAndGetCharWidth(context, ringList.pollFirst(), useIntWidth);
+								float w = prepareAndGetCharWidth(context, ringList.pollFirst());
 								total_width += w;
 							}
 							widths[i] = total_width;
@@ -530,18 +529,18 @@ public class RenderFontUtil {
 					//§の次が無い
 					float w;
 					if (context.isEdit)
-						w = getCharWidthWithSpace(context.fontRenderer, '§', getInvalidDisplayEffects(), useIntWidth);
+						w = getCharWidthWithSpace(context.fontRenderer, '§', getInvalidDisplayEffects());
 					else
-						w = getCharWidthWithSpace(context.fontRenderer, '§', Collections.emptyList(), useIntWidth);
+						w = getCharWidthWithSpace(context.fontRenderer, '§', Collections.emptyList());
 					widths[beginIndex] = w;
 				}
 				case ESCAPED_SECTION_SIGN -> {
 					if (context.isEdit) {
-						float w = getCharWidthWithSpace(context.fontRenderer, '§', getValidDisplayEffects(), useIntWidth);
+						float w = getCharWidthWithSpace(context.fontRenderer, '§', getValidDisplayEffects());
 						widths[beginIndex] = w;
 						widths[beginIndex + 1] = w;
 					} else {
-						float w = prepareAndGetCharWidth(context, '§', useIntWidth);
+						float w = prepareAndGetCharWidth(context, '§');
 						if (reverse)
 							widths[beginIndex] = w;
 						else
@@ -550,7 +549,7 @@ public class RenderFontUtil {
 				}
 				case FORMATTING_CODE_UNTERMINATED_LONGKEY, FORMATTING_CODE_UNKNOWN -> {
 					for (int i = beginIndex; i < endIndexExcl; i++) {
-						float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects(), useIntWidth);
+						float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects());
 						widths[i] = w;
 					}
 				}
@@ -559,14 +558,14 @@ public class RenderFontUtil {
 						pair.getValue().applyFormat(context, option);
 						if (context.isEdit) {
 							for (int i = beginIndex; i < endIndexExcl; i++) {
-								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 								widths[i] = w;
 							}
 						} else {
 							float total_width = 0;
 							CharArrayRingList ringList = context.getRingList();
 							while (!ringList.isEmpty()) {
-								float w = prepareAndGetCharWidth(context, ringList.pollFirst(), useIntWidth);
+								float w = prepareAndGetCharWidth(context, ringList.pollFirst());
 								total_width += w;
 							}
 							if (reverse)
@@ -576,7 +575,7 @@ public class RenderFontUtil {
 						}
 					} else {
 						for (int i = beginIndex; i < endIndexExcl; i++) {
-							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects(), useIntWidth);
+							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getInvalidDisplayEffects());
 							widths[i] = w;
 						}
 					}
@@ -585,14 +584,14 @@ public class RenderFontUtil {
 					Collection<IRenderingCharEffect> effects_before = new ArrayList<>(context.effects);
 					if (context.isEdit) {
 						for (int i = beginIndex; i < beginIndex + 1 + markerNum; i++) {
-							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+							float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 							widths[i] = w;
 						}
 					} else {
 						if (type == Type.FORMATTING_RANGE_UNTERMINATED) {
 							float total_width = 0;
 							for (int i = beginIndex; i < beginIndex + 1 + markerNum; i++) {
-								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 								total_width += w;
 							}
 							if (reverse)
@@ -608,7 +607,7 @@ public class RenderFontUtil {
 					if (context.isEdit) {
 						if (type == Type.FORMATTING_RANGE) {
 							for (int i = endIndexExcl - markerNum; i < endIndexExcl; i++) {
-								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects(), useIntWidth);
+								float w = getCharWidthWithSpace(context.fontRenderer, context.originalText.charAt(i), getValidDisplayEffects());
 								widths[i] = w;
 							}
 						}
@@ -859,7 +858,7 @@ public class RenderFontUtil {
 				} else if (ch == ' ') {
 					whiteSpaceIdx = i;
 				} else {
-					float w = getCharWidthWithSpace(fontRenderer, ch, effects, RenderFontUtil.useIntWidth);
+					float w = getCharWidthWithSpace(fontRenderer, ch, effects);
 					if (currentWidth + w > wrapWidth) {
 						if (whiteSpaceIdx == -1 && newLineIfNoSpace) {
 							//空白が無いので全て次の行に持っていく
@@ -881,7 +880,7 @@ public class RenderFontUtil {
 								startIndex = whiteSpaceIdx + 1;//空白を含めない
 							} else {
 								startIndex = whiteSpaceIdx;
-								currentWidth += getCharWidthRaw(fontRenderer, ' ', RenderFontUtil.useIntWidth);
+								currentWidth += getCharWidthRaw(fontRenderer, ' ');
 							}
 							whiteSpaceIdx = -1;
 						}
@@ -940,7 +939,7 @@ public class RenderFontUtil {
 	public static float renderRawString(FontRenderer fontRenderer, String text, float posX, float posY, boolean asShadow) {
 		float x = posX;
 		for (int i = 0; i < text.length(); i++) {
-			x += renderChar(fontRenderer, text.charAt(i), x, posY, Collections.emptyList(), asShadow, useIntWidth);
+			x += renderChar(fontRenderer, text.charAt(i), x, posY, Collections.emptyList(), asShadow);
 		}
 		return x;
 	}
@@ -950,10 +949,10 @@ public class RenderFontUtil {
 		endIndex = Math.min(endIndex, text.length());
 		return FormattedStringObject.render(fontRenderer, text, beginIndex, endIndex, posX, posY, asShadow);
 	}
-	public static float renderChar(FontRenderer fontRenderer, char ch, float posX, float posY, Collection<IRenderingCharEffect> effects, boolean asShadow, boolean useIntWidth) {
-		return renderChar(fontRenderer, ch, posX, posY, effects, asShadow, useIntWidth, false, GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING));
+	public static float renderChar(FontRenderer fontRenderer, char ch, float posX, float posY, Collection<IRenderingCharEffect> effects, boolean asShadow) {
+		return renderChar(fontRenderer, ch, posX, posY, effects, asShadow, false, GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING));
 	}
-	private static float renderChar(FontRenderer fontRenderer, char ch, float posX, float posY, Collection<IRenderingCharEffect> effects, boolean asShadow, boolean useIntWidth, boolean isStringRendering, int framebufferObject) {
+	private static float renderChar(FontRenderer fontRenderer, char ch, float posX, float posY, Collection<IRenderingCharEffect> effects, boolean asShadow, boolean isStringRendering, int framebufferObject) {
 		if (ch == 0)
 			return 0;
 		float char_width;
@@ -1008,10 +1007,7 @@ public class RenderFontUtil {
 		for (IRenderingCharEffect effect : effects) {
 			effect.postRender(context);
 		}
-		if (useIntWidth)
-			return (int) context.nextRenderXOffset;
-		else
-			return context.nextRenderXOffset;
+		return context.nextRenderXOffset;
 	}
 	public static void renderCharRaw(float red, float green, float blue, float alpha, float minU, float minV, float maxU, float maxV, float leftTopX, float leftTopY, float leftTopZ, float leftBottomX, float leftBottomY, float leftBottomZ, float rightTopX, float rightTopY, float rightTopZ, float rightBottomX, float rightBottomY, float rightBottomZ) {
 		GlStateManager.color(red, green, blue, alpha);
@@ -1026,7 +1022,7 @@ public class RenderFontUtil {
 		GlStateManager.glVertex3f(rightBottomX, rightBottomY, rightBottomZ);
 		GlStateManager.glEnd();
 	}
-	private static float prepareAndRenderChar(RenderingStringContext context, char ch, boolean useIntWidth) {
+	private static float prepareAndRenderChar(RenderingStringContext context, char ch) {
 		PreparingContext prepare = new PreparingContext(context.fontRenderer, ch, context.isEdit, true, context.originalText, context.tryGetRingList(), context.effects);
 		boolean cancelled = false;
 		for (IRenderingCharEffect effect : context.effects) {
@@ -1042,7 +1038,7 @@ public class RenderFontUtil {
 			return width;
 		}
 
-		return renderChar(context.fontRenderer, prepare.charToRender, context.posX, context.posY, context.effects, context.asShadow, useIntWidth, true, context.framebufferObject);
+		return renderChar(context.fontRenderer, prepare.charToRender, context.posX, context.posY, context.effects, context.asShadow, true, context.framebufferObject);
 	}
 
 	//getWidth
@@ -1052,7 +1048,7 @@ public class RenderFontUtil {
 	public static float getRawStringWidthFloat(FontRenderer fontRenderer, String text) {
 		float total_width = 0;
 		for (int i = 0; i < text.length(); i++) {
-			total_width += getCharWidthWithSpace(fontRenderer, text.charAt(i), Collections.emptyList(), useIntWidth);
+			total_width += getCharWidthWithSpace(fontRenderer, text.charAt(i), Collections.emptyList());
 		}
 		return total_width;
 	}
@@ -1064,10 +1060,10 @@ public class RenderFontUtil {
 		context.effects.addAll(appliedEffects);
 		return FormattedStringObject.parse(text).measure(context, beginIndex, endIndex, Float.POSITIVE_INFINITY).totalWidth;
 	}
-	public static float getCharWidthWithSpace(FontRenderer fontRenderer, char ch, Collection<IRenderingCharEffect> effects, boolean useIntWidth) {
+	public static float getCharWidthWithSpace(FontRenderer fontRenderer, char ch, Collection<IRenderingCharEffect> effects) {
 		if (ch == 0)
 			return 0;
-		float char_width = getCharWidthRaw(fontRenderer, ch, false);
+		float char_width = getCharWidthRaw(fontRenderer, ch);
 		MeasuringCharWidthContext context = new MeasuringCharWidthContext(fontRenderer, ch, char_width, CHAR_HEIGHT);
 		for (IRenderingCharEffect effect : effects) {
 			effect.first(context);
@@ -1075,12 +1071,9 @@ public class RenderFontUtil {
 		for (IRenderingCharEffect effect : effects) {
 			effect.second(context);
 		}
-		if (useIntWidth)
-			return (int) context.charWidthWithSpace;
-		else
-			return context.charWidthWithSpace;
+		return context.charWidthWithSpace;
 	}
-	public static float getCharWidthRaw(FontRenderer fontRenderer, char ch, boolean useIntWidth) {
+	public static float getCharWidthRaw(FontRenderer fontRenderer, char ch) {
 		if (ch == 0)
 			return 0;
 		float char_width;
@@ -1097,12 +1090,9 @@ public class RenderFontUtil {
 				char_width = (right + 1 - left) / 2;
 			}
 		}
-		if (useIntWidth)
-			return (int) char_width;
-		else
-			return char_width;
+		return char_width;
 	}
-	private static float prepareAndGetCharWidth(MeasuringStringWidthContext context, char ch, boolean useIntWidth) {
+	private static float prepareAndGetCharWidth(MeasuringStringWidthContext context, char ch) {
 		PreparingContext prepare = new PreparingContext(context.fontRenderer, ch, context.isEdit, false, context.originalText, context.tryGetRingList(), context.effects);
 		boolean cancelled = false;
 		for (IRenderingCharEffect effect : context.effects) {
@@ -1117,7 +1107,7 @@ public class RenderFontUtil {
 			}
 			return width;
 		}
-		return getCharWidthWithSpace(context.fontRenderer, prepare.charToRender, context.effects, useIntWidth);
+		return getCharWidthWithSpace(context.fontRenderer, prepare.charToRender, context.effects);
 	}
 
 	//trim
@@ -1132,7 +1122,7 @@ public class RenderFontUtil {
 			float total_width = 0;
 			for (int i = 0; i < text.length(); i++) {
 				char c0 = text.charAt(i);
-				total_width += getCharWidthWithSpace(fontRenderer, c0, Collections.emptyList(), RenderFontUtil.useIntWidth);
+				total_width += getCharWidthWithSpace(fontRenderer, c0, Collections.emptyList());
 				if (total_width > width) {
 					return text.substring(0, i);//今見た文字は含まれない
 				}
@@ -1142,7 +1132,7 @@ public class RenderFontUtil {
 			float total_width = 0;
 			for (int i = text.length() - 1; i >= 0; i--) {
 				char c0 = text.charAt(i);
-				total_width += getCharWidthWithSpace(fontRenderer, c0, Collections.emptyList(), RenderFontUtil.useIntWidth);
+				total_width += getCharWidthWithSpace(fontRenderer, c0, Collections.emptyList());
 				if (total_width > width)
 					return text.substring(i + 1);//今見た文字は含まない
 			}
@@ -1435,12 +1425,6 @@ public class RenderFontUtil {
 		if (fontRenderer.unicodeFlag)
 			return -1;
 		return ASCII_CHARS.indexOf(c);
-	}
-	public static float toIntWidthIfForced(float width) {
-		if (useIntWidth)
-			return (int) width;
-		else
-			return width;
 	}
 
 	public static class MeasuringResult {

--- a/src/main/java/kpan/better_fc/api/RenderFontUtil.java
+++ b/src/main/java/kpan/better_fc/api/RenderFontUtil.java
@@ -957,12 +957,12 @@ public class RenderFontUtil {
 	private static float renderChar(FontRenderer fontRenderer, char ch, float posX, float posY, Collection<IRenderingCharEffect> effects, boolean asShadow, boolean isStringRendering, int framebufferObject) {
 		if (ch == 0)
 			return 0;
-		float char_width;
+		float char_rendering_width;
 		float next_render_x_offset;
 		float min_u;
 		float min_v;
 		if (ch == ' ') {
-			char_width = 3;
+			char_rendering_width = 3;
 			next_render_x_offset = 4;
 			min_u = 0;
 			min_v = 0;
@@ -970,7 +970,7 @@ public class RenderFontUtil {
 			int index = getAsciiCharIndex(fontRenderer, ch);
 			if (index != -1) {
 				float cw = getCharWidthRaw(fontRenderer, ch);
-				char_width = cw - 0.01f;
+				char_rendering_width = cw - 0.01f;
 				next_render_x_offset = cw + 1;
 				int i = index % 16 * 8;
 				int j = index / 16 * 8;
@@ -982,7 +982,7 @@ public class RenderFontUtil {
 				int texture_index = ch / 256;
 				float left = width_data >>> 4;
 				float right = width_data & 15;
-				char_width = (right + 1 - left - 0.02f) / 2;
+				char_rendering_width = (right + 1 - left - 0.02f) / 2;
 				next_render_x_offset = (right + 1 - left) / 2 + 1;
 				if (CompatOptifine.isOptifineLoaded())
 					next_render_x_offset = (int) next_render_x_offset;
@@ -998,7 +998,7 @@ public class RenderFontUtil {
 			}
 		}
 		//greenとblueが逆なのはバニラが悪い
-		RenderingCharContext context = new RenderingCharContext(fontRenderer, ch, char_width, CHAR_HEIGHT, asShadow, isStringRendering, min_u, min_v, posX, posY, fontRenderer.red, fontRenderer.blue, fontRenderer.green, fontRenderer.alpha, next_render_x_offset, framebufferObject);
+		RenderingCharContext context = new RenderingCharContext(fontRenderer, ch, char_rendering_width, CHAR_HEIGHT, asShadow, isStringRendering, min_u, min_v, posX, posY, fontRenderer.red, fontRenderer.blue, fontRenderer.green, fontRenderer.alpha, next_render_x_offset, framebufferObject);
 		for (IRenderingCharEffect effect : effects) {
 			effect.preRender(context);
 		}
@@ -1077,6 +1077,9 @@ public class RenderFontUtil {
 		}
 		return context.charWidthWithSpace;
 	}
+	/***
+	 * Get char width without space(=fontRenderer.getCharWidth()-1)
+	 */
 	public static float getCharWidthRaw(FontRenderer fontRenderer, char ch) {
 		if (ch == 0)
 			return 0;

--- a/src/main/java/kpan/better_fc/api/StencilTextRenderer.java
+++ b/src/main/java/kpan/better_fc/api/StencilTextRenderer.java
@@ -39,6 +39,13 @@ public class StencilTextRenderer implements IStringRenderEndListener {
 		renderer.accept(context);
 		GL11.glDisable(GL11.GL_STENCIL_TEST);
 
+		GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+		GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, context.framebufferObject);
+		GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, framebuffer.framebufferObject);
+		int w = GLStateManagerUtil.viewportWidth;
+		int h = GLStateManagerUtil.viewportHeight;
+		GL30.glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL11.GL_DEPTH_BUFFER_BIT, GL11.GL_NEAREST);
+
 		OpenGlHelper.glBindFramebuffer(OpenGlHelper.GL_FRAMEBUFFER, context.framebufferObject);
 		GlStateManager.matrixMode(GL11.GL_MODELVIEW);
 		GlStateManager.pushMatrix();
@@ -93,8 +100,12 @@ public class StencilTextRenderer implements IStringRenderEndListener {
 	}
 
 	public void clear(RenderingStringContext context) {
-		if (framebuffer == null) {
-			framebuffer = new Framebuffer(GLStateManagerUtil.viewportWidth, GLStateManagerUtil.viewportHeight, true);
+		if (framebuffer == null || GLStateManagerUtil.viewportWidth > framebuffer.framebufferWidth || GLStateManagerUtil.viewportHeight > framebuffer.framebufferHeight) {
+			int w = Math.max(GLStateManagerUtil.viewportWidth, Minecraft.getMinecraft().displayWidth);
+			int h = Math.max(GLStateManagerUtil.viewportHeight, Minecraft.getMinecraft().displayHeight);
+			if (framebuffer != null)
+				framebuffer.deleteFramebuffer();
+			framebuffer = new Framebuffer(w, h, true);
 			framebuffer.setFramebufferColor(0.0F, 0.0F, 0.0F, 0.0F);
 			framebuffer.enableStencil();
 		}
@@ -103,11 +114,9 @@ public class StencilTextRenderer implements IStringRenderEndListener {
 		GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
 		GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, framebuffer.framebufferObject);
 		GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, context.framebufferObject);
-		int x = GLStateManagerUtil.viewportX;
-		int y = GLStateManagerUtil.viewportY;
 		int w = GLStateManagerUtil.viewportWidth;
 		int h = GLStateManagerUtil.viewportHeight;
-		GL30.glBlitFramebuffer(x, y, w, h, x, y, w, h, GL11.GL_DEPTH_BUFFER_BIT, GL11.GL_NEAREST);
+		GL30.glBlitFramebuffer(0, 0, w, h, 0, 0, w, h, GL11.GL_DEPTH_BUFFER_BIT, GL11.GL_NEAREST);
 		OpenGlHelper.glBindFramebuffer(OpenGlHelper.GL_FRAMEBUFFER, context.framebufferObject);
 	}
 }

--- a/src/main/java/kpan/better_fc/api/contexts/chara/RenderingCharContext.java
+++ b/src/main/java/kpan/better_fc/api/contexts/chara/RenderingCharContext.java
@@ -7,7 +7,7 @@ public class RenderingCharContext {
 
 	public final FontRenderer fontRenderer;
 	public final char charToRender;
-	public final float charWidth;
+	public final float charRenderingWidth;
 	public final float charHeight;
 	public final boolean asShadow;
 	public final boolean isStringRendering;
@@ -40,24 +40,24 @@ public class RenderingCharContext {
 	public float renderedWidth;
 
 
-	public RenderingCharContext(FontRenderer fontRenderer, char c, float charWidth, float charHeight, boolean asShadow, boolean isStringRendering, float minU, float minV, float posX, float posY, float red, float green, float blue, float alpha, float nextRenderXOffset, int framebufferObject) {
+	public RenderingCharContext(FontRenderer fontRenderer, char c, float charRenderingWidth, float charHeight, boolean asShadow, boolean isStringRendering, float minU, float minV, float posX, float posY, float red, float green, float blue, float alpha, float nextRenderXOffset, int framebufferObject) {
 		this.fontRenderer = fontRenderer;
 		charToRender = c;
-		this.charWidth = charWidth;
+		this.charRenderingWidth = charRenderingWidth;
 		this.charHeight = charHeight;
 		this.asShadow = asShadow;
 		this.isStringRendering = isStringRendering;
 		this.minU = minU;
 		this.minV = minV;
 		this.framebufferObject = framebufferObject;
-		maxU = minU + charWidth / 128f;
+		maxU = minU + charRenderingWidth / 128f;
 		maxV = minV + charHeight / 128f;
 		this.posX = posX;
 		this.posY = posY;
 		renderLeftTopX = 0;
 		renderLeftBottomX = 0;
-		renderRightTopX = charWidth;
-		renderRightBottomX = charWidth;
+		renderRightTopX = charRenderingWidth;
+		renderRightBottomX = charRenderingWidth;
 		renderLeftTopY = 0;
 		renderLeftBottomY = charHeight;
 		renderRightTopY = 0;

--- a/src/main/java/kpan/better_fc/asm/compat/CompatOptifine.java
+++ b/src/main/java/kpan/better_fc/asm/compat/CompatOptifine.java
@@ -1,0 +1,20 @@
+package kpan.better_fc.asm.compat;
+
+public class CompatOptifine {
+	private static final boolean loaded;
+
+	static {
+		boolean tmp;
+		try {
+			Class.forName("optifine.Patcher");
+			tmp = true;
+		} catch (ClassNotFoundException e) {
+			tmp = false;
+		}
+		loaded = tmp;
+	}
+
+	public static boolean isOptifineLoaded() {
+		return loaded;
+	}
+}

--- a/src/main/java/kpan/better_fc/asm/core/ASMTransformer.java
+++ b/src/main/java/kpan/better_fc/asm/core/ASMTransformer.java
@@ -17,6 +17,8 @@ import kpan.better_fc.asm.tf.TF_GuiUtilRenderComponents;
 import kpan.better_fc.asm.tf.TF_GuiWorldEdit;
 import kpan.better_fc.asm.tf.TF_ItemWrittenBook;
 import kpan.better_fc.asm.tf.TF_NetHandlerPlayServer;
+import kpan.better_fc.asm.tf.TF_Render;
+import kpan.better_fc.asm.tf.TF_TeleportToTeam$TeamSelectionObject;
 import kpan.better_fc.asm.tf.TF_TextFormatting;
 import kpan.better_fc.asm.tf.TF_TileEntitySignRenderer;
 import net.minecraft.launchwrapper.IClassTransformer;
@@ -62,6 +64,8 @@ public class ASMTransformer implements IClassTransformer {
 			cv = TF_GuiWorldEdit.appendVisitor(cv, transformedName);
 			cv = TF_ItemWrittenBook.appendVisitor(cv, transformedName);
 			cv = TF_NetHandlerPlayServer.appendVisitor(cv, transformedName);
+			cv = TF_Render.appendVisitor(cv, transformedName);
+			cv = TF_TeleportToTeam$TeamSelectionObject.appendVisitor(cv, transformedName);
 			cv = TF_TextFormatting.appendVisitor(cv, transformedName);
 			cv = TF_TileEntitySignRenderer.appendVisitor(cv, transformedName);
 

--- a/src/main/java/kpan/better_fc/asm/core/ASMTransformer.java
+++ b/src/main/java/kpan/better_fc/asm/core/ASMTransformer.java
@@ -69,7 +69,6 @@ public class ASMTransformer implements IClassTransformer {
 			cv = TF_TextFormatting.appendVisitor(cv, transformedName);
 			cv = TF_TileEntitySignRenderer.appendVisitor(cv, transformedName);
 
-
 			if (cv == cw)
 				return bytes;
 
@@ -81,6 +80,7 @@ public class ASMTransformer implements IClassTransformer {
 			//Writer内の情報をbyte配列にして返す。
 			return new_bytes;
 		} catch (Exception e) {
+			System.out.println(transformedName);
 			System.out.println(e.getMessage());
 			e.printStackTrace();
 			throw e;

--- a/src/main/java/kpan/better_fc/asm/hook/HK_GuiScreenBook.java
+++ b/src/main/java/kpan/better_fc/asm/hook/HK_GuiScreenBook.java
@@ -27,13 +27,13 @@ public class HK_GuiScreenBook {
 
 		if (self.bookGettingSigned) {
 			String editTitle = I18n.format("book.editTitle");
-			float width_editTitle = RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getStringWidthFloat(self.fontRenderer, editTitle));
+			float width_editTitle = RenderFontUtil.getStringWidthFloat(self.fontRenderer, editTitle);
 			RenderFontUtil.drawString(self.fontRenderer, editTitle, startX + 36 + (116 - width_editTitle) / 2, 34, 0);
 			String title = self.bookTitle;
 
 
 			HK_FontRenderer.startEditMode();
-			float width_title = RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getStringWidthFloat(self.fontRenderer, title));
+			float width_title = RenderFontUtil.getStringWidthFloat(self.fontRenderer, title);
 			float x = RenderFontUtil.drawString(self.fontRenderer, title, startX + 36 + (116 - width_title) / 2, 50, 0);
 			HK_FontRenderer.endEditMode();
 			if (self.bookIsUnsigned) {
@@ -46,7 +46,7 @@ public class HK_GuiScreenBook {
 				RenderFontUtil.drawString(self.fontRenderer, cursor, x, 50, 0, false);
 			}
 			String byAuthor = I18n.format("book.byAuthor", self.editingPlayer.getName());
-			float width_byAuthor = RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getStringWidthFloat(self.fontRenderer, byAuthor));
+			float width_byAuthor = RenderFontUtil.getStringWidthFloat(self.fontRenderer, byAuthor);
 			RenderFontUtil.drawString(self.fontRenderer, TextFormatting.DARK_GRAY + byAuthor, startX + 36 + (116 - width_byAuthor) / 2, 60, 0);
 			String finalizeWarning = I18n.format("book.finalizeWarning");
 			RenderFontUtil.drawSplitString(self.fontRenderer, finalizeWarning, startX + 36, 82, 116, 0);
@@ -74,7 +74,7 @@ public class HK_GuiScreenBook {
 				self.cachedPage = self.currPage;
 			}
 
-			float j1 = RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getStringWidthFloat(self.fontRenderer, pageIndicator));
+			float j1 = RenderFontUtil.getStringWidthFloat(self.fontRenderer, pageIndicator);
 			RenderFontUtil.drawString(self.fontRenderer, pageIndicator, startX - j1 + 192 - 44, 18, 0);
 
 			if (self.cachedComponents == null) {

--- a/src/main/java/kpan/better_fc/asm/hook/HK_Render.java
+++ b/src/main/java/kpan/better_fc/asm/hook/HK_Render.java
@@ -1,0 +1,12 @@
+package kpan.better_fc.asm.hook;
+
+import kpan.better_fc.api.RenderFontUtil;
+import net.minecraft.client.gui.FontRenderer;
+
+@SuppressWarnings("unused")
+public class HK_Render {
+
+	public static int getColor(FontRenderer fontRenderer, String text) {
+		return RenderFontUtil.getColor(fontRenderer, RenderFontUtil.getEffects(text));
+	}
+}

--- a/src/main/java/kpan/better_fc/asm/hook/HK_TeleportToTeam$TeamSelectionObject.java
+++ b/src/main/java/kpan/better_fc/asm/hook/HK_TeleportToTeam$TeamSelectionObject.java
@@ -1,0 +1,12 @@
+package kpan.better_fc.asm.hook;
+
+import kpan.better_fc.api.RenderFontUtil;
+import net.minecraft.client.gui.FontRenderer;
+
+@SuppressWarnings("unused")
+public class HK_TeleportToTeam$TeamSelectionObject {
+
+	public static int getColor(FontRenderer fontRenderer, String text) {
+		return RenderFontUtil.getColor(fontRenderer, RenderFontUtil.getEffects(text));
+	}
+}

--- a/src/main/java/kpan/better_fc/asm/hook/HK_TileEntitySignRenderer.java
+++ b/src/main/java/kpan/better_fc/asm/hook/HK_TileEntitySignRenderer.java
@@ -22,16 +22,16 @@ public class HK_TileEntitySignRenderer {
 		RenderHelper.disableStandardItemLighting();
 		if (HK_GuiEditSign.editLine == j) {
 			HK_FontRenderer.startEditMode();
-			float w = RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getStringWidthFloat(fontrenderer, s));
+			float w = RenderFontUtil.getStringWidthFloat(fontrenderer, s);
 			RenderFontUtil.drawString(fontrenderer, s, -w / 2, y, 0);
 			HK_FontRenderer.endEditMode();
 			if (j == te.lineBeingEdited) {
-				RenderFontUtil.drawString(fontrenderer, "> ", -w / 2 - RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getStringWidthFloat(fontrenderer, "> ")), y, 0);
+				RenderFontUtil.drawString(fontrenderer, "> ", -w / 2 - RenderFontUtil.getStringWidthFloat(fontrenderer, "> "), y, 0);
 				RenderFontUtil.drawString(fontrenderer, " <", w / 2, y, 0);
 			}
 		} else {
 			int end = RenderFontUtil.getEndIndexExcOfTrimmedSubString(fontrenderer, s, 0, 95);//ピッタリは96だけど斜めから見るとちょっとはみ出る(なんなら95もわずかにはみ出る)
-			float w = RenderFontUtil.toIntWidthIfForced(RenderFontUtil.getSubStringWidthFloat(fontrenderer, s, 0, end));
+			float w = RenderFontUtil.getSubStringWidthFloat(fontrenderer, s, 0, end);
 			RenderFontUtil.drawSubString(fontrenderer, s, 0, end, -w / 2, y, 0);
 		}
 		if (isLightingEnabled)

--- a/src/main/java/kpan/better_fc/asm/hook/HK_TileEntitySignRenderer.java
+++ b/src/main/java/kpan/better_fc/asm/hook/HK_TileEntitySignRenderer.java
@@ -10,7 +10,7 @@ import org.lwjgl.opengl.GL11;
 
 @SuppressWarnings("unused")
 public class HK_TileEntitySignRenderer {
-	public static void onRenderText(TileEntitySign te, FontRenderer fontrenderer, int j) {
+	public static void onRenderText(TileEntitySign te, FontRenderer fontrenderer, int color, int j) {
 		ITextComponent itextcomponent = te.signText[j];
 		String s = itextcomponent.getFormattedText();
 		if (!s.isEmpty())
@@ -23,16 +23,16 @@ public class HK_TileEntitySignRenderer {
 		if (HK_GuiEditSign.editLine == j) {
 			HK_FontRenderer.startEditMode();
 			float w = RenderFontUtil.getStringWidthFloat(fontrenderer, s);
-			RenderFontUtil.drawString(fontrenderer, s, -w / 2, y, 0);
+			RenderFontUtil.drawString(fontrenderer, s, -w / 2, y, color);
 			HK_FontRenderer.endEditMode();
 			if (j == te.lineBeingEdited) {
-				RenderFontUtil.drawString(fontrenderer, "> ", -w / 2 - RenderFontUtil.getStringWidthFloat(fontrenderer, "> "), y, 0);
-				RenderFontUtil.drawString(fontrenderer, " <", w / 2, y, 0);
+				RenderFontUtil.drawString(fontrenderer, "> ", -w / 2 - RenderFontUtil.getStringWidthFloat(fontrenderer, "> "), y, color);
+				RenderFontUtil.drawString(fontrenderer, " <", w / 2, y, color);
 			}
 		} else {
 			int end = RenderFontUtil.getEndIndexExcOfTrimmedSubString(fontrenderer, s, 0, 95);//ピッタリは96だけど斜めから見るとちょっとはみ出る(なんなら95もわずかにはみ出る)
 			float w = RenderFontUtil.getSubStringWidthFloat(fontrenderer, s, 0, end);
-			RenderFontUtil.drawSubString(fontrenderer, s, 0, end, -w / 2, y, 0);
+			RenderFontUtil.drawSubString(fontrenderer, s, 0, end, -w / 2, y, color);
 		}
 		if (isLightingEnabled)
 			RenderHelper.enableStandardItemLighting();

--- a/src/main/java/kpan/better_fc/asm/tf/TF_Render.java
+++ b/src/main/java/kpan/better_fc/asm/tf/TF_Render.java
@@ -1,0 +1,45 @@
+package kpan.better_fc.asm.tf;
+
+import kpan.better_fc.asm.core.AsmTypes;
+import kpan.better_fc.asm.core.AsmUtil;
+import kpan.better_fc.asm.core.MyAsmNameRemapper.MethodRemap;
+import kpan.better_fc.asm.core.adapters.Instructions;
+import kpan.better_fc.asm.core.adapters.MyClassVisitor;
+import kpan.better_fc.asm.core.adapters.ReplaceInstructionsAdapter;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class TF_Render {
+
+	private static final String TARGET = "net.minecraft.client.renderer.entity.Render";
+	private static final String HOOK = AsmTypes.HOOK + "HK_" + "Render";
+	private static final MethodRemap getTeamColor = new MethodRemap(TARGET, "getTeamColor", AsmUtil.toMethodDesc(AsmTypes.INT, AsmTypes.ENTITY), "func_188298_c");
+	private static final MethodRemap getColorCode = new MethodRemap(References.FontRenderer, "getColorCode", AsmUtil.toMethodDesc(AsmTypes.INT, AsmTypes.CHAR), "func_175064_b");
+
+	public static ClassVisitor appendVisitor(ClassVisitor cv, String className) {
+		if (!TARGET.equals(className))
+			return cv;
+		MyClassVisitor newcv = new MyClassVisitor(cv, className) {
+			@Override
+			public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+				MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+				if (getTeamColor.isTarget(name, desc)) {
+					mv = new ReplaceInstructionsAdapter(mv, name
+							, Instructions.create()
+							.aload(4)
+							.insn(Opcodes.ICONST_1)
+							.invokeVirtual(AsmTypes.STRING, "charAt", AsmUtil.toMethodDesc(AsmTypes.CHAR, AsmTypes.INT))
+							.invokeVirtual(getColorCode)
+							, Instructions.create()
+							.aload(4)
+							.invokeStatic(HOOK, "getColor", AsmUtil.toMethodDesc(AsmTypes.INT, References.FontRenderer, AsmTypes.STRING))
+					);
+					success();
+				}
+				return mv;
+			}
+		};
+		return newcv;
+	}
+}

--- a/src/main/java/kpan/better_fc/asm/tf/TF_TeleportToTeam$TeamSelectionObject.java
+++ b/src/main/java/kpan/better_fc/asm/tf/TF_TeleportToTeam$TeamSelectionObject.java
@@ -1,0 +1,45 @@
+package kpan.better_fc.asm.tf;
+
+import kpan.better_fc.asm.core.AsmTypes;
+import kpan.better_fc.asm.core.AsmUtil;
+import kpan.better_fc.asm.core.MyAsmNameRemapper.MethodRemap;
+import kpan.better_fc.asm.core.adapters.Instructions;
+import kpan.better_fc.asm.core.adapters.MyClassVisitor;
+import kpan.better_fc.asm.core.adapters.ReplaceInstructionsAdapter;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class TF_TeleportToTeam$TeamSelectionObject {
+
+	private static final String TARGET = "net.minecraft.client.gui.spectator.categories.TeleportToTeam$TeamSelectionObject";
+	private static final String HOOK = AsmTypes.HOOK + "HK_" + "TeleportToTeam$TeamSelectionObject";
+	private static final MethodRemap renderIcon = new MethodRemap(TARGET, "renderIcon", AsmUtil.toMethodDesc(AsmTypes.VOID, AsmTypes.FLOAT, AsmTypes.INT), "func_178663_a");
+	private static final MethodRemap getColorCode = new MethodRemap(References.FontRenderer, "getColorCode", AsmUtil.toMethodDesc(AsmTypes.INT, AsmTypes.CHAR), "func_175064_b");
+
+	public static ClassVisitor appendVisitor(ClassVisitor cv, String className) {
+		if (!TARGET.equals(className))
+			return cv;
+		MyClassVisitor newcv = new MyClassVisitor(cv, className) {
+			@Override
+			public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+				MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+				if (renderIcon.isTarget(name, desc)) {
+					mv = new ReplaceInstructionsAdapter(mv, name
+							, Instructions.create()
+							.aload(4)
+							.insn(Opcodes.ICONST_1)
+							.invokeVirtual(AsmTypes.STRING, "charAt", AsmUtil.toMethodDesc(AsmTypes.CHAR, AsmTypes.INT))
+							.invokeVirtual(getColorCode)
+							, Instructions.create()
+							.aload(4)
+							.invokeStatic(HOOK, "getColor", AsmUtil.toMethodDesc(AsmTypes.INT, References.FontRenderer, AsmTypes.STRING))
+					);
+					success();
+				}
+				return mv;
+			}
+		};
+		return newcv;
+	}
+}

--- a/src/main/java/kpan/better_fc/asm/tf/TF_TileEntitySignRenderer.java
+++ b/src/main/java/kpan/better_fc/asm/tf/TF_TileEntitySignRenderer.java
@@ -1,5 +1,6 @@
 package kpan.better_fc.asm.tf;
 
+import kpan.better_fc.asm.compat.CompatOptifine;
 import kpan.better_fc.asm.core.AsmTypes;
 import kpan.better_fc.asm.core.AsmUtil;
 import kpan.better_fc.asm.core.MyAsmNameRemapper.FieldRemap;
@@ -45,6 +46,8 @@ public class TF_TileEntitySignRenderer {
 		//おそらくRFGのせいだろう
 		if (AsmUtil.isDeobfEnvironment())
 			return targetInDev();
+		else if (CompatOptifine.isOptifineLoaded())
+			return targetWithOptifine();
 		else
 			return targetInRuntime();
 	}
@@ -136,12 +139,54 @@ public class TF_TileEntitySignRenderer {
 		}
 		return instrs;
 	}
+	private static Instructions targetWithOptifine() {
+		Instructions instrs = Instructions.create();
+		instrs.aload(1);
+		instrs.getField(signText);
+		instrs.iload(16);
+		instrs.insn(Opcodes.AALOAD);
+		instrs.rep();
+		instrs.label(51);
+		for (int i = 0; i < 7; i++) {
+			instrs.rep();
+		}
+		instrs.label(52);
+		for (int i = 0; i < 11; i++) {
+			instrs.rep();
+		}
+		instrs.label(53);
+		for (int i = 0; i < 1; i++) {
+			instrs.rep();
+		}
+		instrs.label(54);
+		for (int i = 0; i < 1; i++) {
+			instrs.rep();
+		}
+		instrs.label(55);
+		for (int i = 0; i < 4; i++) {
+			instrs.rep();
+		}
+		instrs.label(57);
+		for (int i = 0; i < 11; i++) {
+			instrs.rep();
+		}
+		instrs.label(58);
+		for (int i = 0; i < 21; i++) {
+			instrs.rep();
+		}
+		instrs.label(56);
+		for (int i = 0; i < 20; i++) {
+			instrs.rep();
+		}
+		return instrs;
+	}
 	private static Instructions replace() {
 		Instructions instrs = Instructions.create();
 		instrs.aload(1);
 		instrs.aload(13);
+		instrs.iload(15);
 		instrs.iload(16);
-		instrs.invokeStatic(HOOK, "onRenderText", AsmUtil.toMethodDesc(AsmTypes.VOID, "net/minecraft/tileentity/TileEntitySign", "net.minecraft.client.gui.FontRenderer", AsmTypes.INT));
+		instrs.invokeStatic(HOOK, "onRenderText", AsmUtil.toMethodDesc(AsmTypes.VOID, "net/minecraft/tileentity/TileEntitySign", "net.minecraft.client.gui.FontRenderer", AsmTypes.INT, AsmTypes.INT));
 		return instrs;
 	}
 

--- a/src/main/java/kpan/better_fc/compat/optifine/CompatCustomColors.java
+++ b/src/main/java/kpan/better_fc/compat/optifine/CompatCustomColors.java
@@ -1,0 +1,31 @@
+package kpan.better_fc.compat.optifine;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+
+public class CompatCustomColors {
+	private static final MethodHandle getTextColor;
+
+	static {
+		MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+		try {
+			{
+				Method m = Class.forName("net.optifine.CustomColors").getDeclaredMethod("getTextColor", int.class, int.class);
+				getTextColor = lookup.unreflect(m);
+			}
+		} catch (NoSuchMethodException | IllegalAccessException | ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static int getTextColor(int index, int defaultColor) {
+		try {
+			return (int) getTextColor.invokeExact(index, defaultColor);
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/src/main/java/kpan/better_fc/compat/optifine/CompatFontRenderer.java
+++ b/src/main/java/kpan/better_fc/compat/optifine/CompatFontRenderer.java
@@ -1,0 +1,48 @@
+package kpan.better_fc.compat.optifine;
+
+import net.minecraft.client.gui.FontRenderer;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class CompatFontRenderer {
+
+	private static final MethodHandle getCharWidthFloat;
+	private static final MethodHandle offsetBold;
+
+	static {
+		MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+		try {
+			{
+				Method m = FontRenderer.class.getDeclaredMethod("getCharWidthFloat", char.class);
+				m.setAccessible(true);
+				getCharWidthFloat = lookup.unreflect(m);
+			}
+			{
+				Field f = FontRenderer.class.getField("offsetBold");
+				offsetBold = lookup.unreflectGetter(f);
+			}
+		} catch (NoSuchMethodException | IllegalAccessException | NoSuchFieldException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static float getCharWidthFloat(FontRenderer fontRenderer, char ch) {
+		try {
+			return (float) getCharWidthFloat.invokeExact(fontRenderer, ch);
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static float getOffsetBold(FontRenderer fontRenderer) {
+		try {
+			return (float) offsetBold.invokeExact(fontRenderer);
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/kpan/better_fc/implementations/formattingcode/vanilla/RenderingEffectBold.java
+++ b/src/main/java/kpan/better_fc/implementations/formattingcode/vanilla/RenderingEffectBold.java
@@ -19,7 +19,7 @@ public class RenderingEffectBold implements IRenderingEffectFancyStyle {
 
 	@Override
 	public void second(MeasuringCharWidthContext context) {
-		context.charWidthWithSpace += 1;
+		context.charWidthWithSpace += 1;//optifineのoffsetBoldは無視する
 	}
 	@Override
 	public int priority() { return 90000; }
@@ -29,11 +29,11 @@ public class RenderingEffectBold implements IRenderingEffectFancyStyle {
 			float offset = getOffset(context.fontRenderer, context.charToRender);
 			RenderFontUtil.renderCharRaw(context.red, context.green, context.blue, context.alpha, context.minU, context.minV, context.maxU, context.maxV, context.posX + context.renderLeftTopX + offset, context.posY + context.renderLeftTopY, context.renderLeftTopZ, context.posX + context.renderLeftBottomX + offset, context.posY + context.renderLeftBottomY, context.renderLeftBottomZ, context.posX + context.renderRightTopX + offset, context.posY + context.renderRightTopY, context.renderRightTopZ, context.posX + context.renderRightBottomX + offset, context.posY + context.renderRightBottomY, context.renderRightBottomZ);
 		}
-		context.nextRenderXOffset += 1;
+		context.nextRenderXOffset += 1;//optifineのoffsetBoldは無視する
 	}
 	private static float getOffset(FontRenderer fontRenderer, char c) {
 		if (RenderFontUtil.getAsciiCharIndex(fontRenderer, c) != -1)
-			return 1f;
+			return RenderFontUtil.getOffsetBold(fontRenderer);//ここだけはoffsetBoldを使おう
 		else
 			return 0.5f;
 	}

--- a/src/main/java/kpan/better_fc/implementations/formattingcode/vanilla/RenderingEffectColor.java
+++ b/src/main/java/kpan/better_fc/implementations/formattingcode/vanilla/RenderingEffectColor.java
@@ -1,10 +1,13 @@
 package kpan.better_fc.implementations.formattingcode.vanilla;
 
-import kpan.better_fc.api.IRenderingEffectColor;
+import kpan.better_fc.api.IRenderingEffectSingleColor;
 import kpan.better_fc.api.contexts.chara.RenderingCharContext;
+import kpan.better_fc.asm.compat.CompatOptifine;
+import kpan.better_fc.compat.optifine.CompatCustomColors;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.util.text.TextFormatting;
 
-public class RenderingEffectColor implements IRenderingEffectColor {
+public class RenderingEffectColor implements IRenderingEffectSingleColor {
 
 	public final TextFormatting color;
 	public RenderingEffectColor(TextFormatting color) {
@@ -13,7 +16,7 @@ public class RenderingEffectColor implements IRenderingEffectColor {
 
 	@Override
 	public void preRender(RenderingCharContext context) {
-		int j1 = context.fontRenderer.colorCode[color.getColorIndex() + (context.asShadow ? 16 : 0)];
+		int j1 = getColor(context.fontRenderer, color.getColorIndex() + (context.asShadow ? 16 : 0));
 		float r = (float) (j1 >> 16) / 255.0F;
 		float g = (float) (j1 >> 8 & 255) / 255.0F;
 		float b = (float) (j1 & 255) / 255.0F;
@@ -23,5 +26,18 @@ public class RenderingEffectColor implements IRenderingEffectColor {
 	}
 
 	@Override
+	public int getColor(FontRenderer fontRenderer) {
+		int index = color.getColorIndex();
+		return getColor(fontRenderer, index);
+	}
+	@Override
 	public int priority() { return 10000; }
+
+	public static int getColor(FontRenderer fontRenderer, int index) {
+		int color = fontRenderer.colorCode[index];
+		if (CompatOptifine.isOptifineLoaded())
+			return CompatCustomColors.getTextColor(index, color);
+		else
+			return color;
+	}
 }

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,0 +1,9 @@
+version 1.1.0 :
+ Add Optifine compatbility.
+ Fix depth buffer bug of StencilTextRenderer.
+ Support team color (glowing effect and spectator menu icon).
+ API update:
+  Remove useIntWidth in RenderFontUtil.
+  Rename RenderingCharContext.charWidth to charRenderingWidth.
+version 1.0.0 :
+ First release.


### PR DESCRIPTION
- Optifineへの対応
- StencilTextRendererにて、デプスバッファが更新されないことによる文字の上書きバグを修正
- チームカラーへの対応 (glowing効果とスペクテイターのメニューアイコン)
- APIの更新：RenderFontUtilのuseIntWidthを削除
- APIの更新：RenderingCharContext.charWidthをcharRenderingWidthにリネーム